### PR TITLE
Javascript and Stylesheet order fix

### DIFF
--- a/bootstrap4/index.php
+++ b/bootstrap4/index.php
@@ -31,15 +31,9 @@ if ($task == "edit" || $layout == "form") {
     $fullWidth = 0;
 }
 
-// Add JavaScript Frameworks
-JHtml::_('jquery.framework');
-$doc->addScript($this->baseurl . '/templates/' . $this->template . '/js/template.js');
-$doc->addScript($this->baseurl . '/templates/' . $this->template . '/js/popper.min.js');
-$doc->addScript($this->baseurl . '/templates/' . $this->template . '/js/bootstrap.min.js');
-
 // Add Stylesheets
-$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/template.css');
 $doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/bootstrap.min.css');
+$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/template.css');
 $doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/font-awesome.min.css');
 
 // Adjusting content width
@@ -147,5 +141,12 @@ if ($this->countModules('sidebar-left') && $this->countModules('sidebar-right'))
             </div>
         </footer>
         <jdoc:include type="modules" name="debug" style="none" />
+		<?php 
+			// Add JavaScript Frameworks - Placed at the end of the document so the pages load faster
+			JHtml::_('jquery.framework');
+			$doc->addScript($this->baseurl . '/templates/' . $this->template . '/js/popper.min.js');
+			$doc->addScript($this->baseurl . '/templates/' . $this->template . '/js/bootstrap.min.js');
+			$doc->addScript($this->baseurl . '/templates/' . $this->template . '/js/template.js');
+		?>
     </body>
 </html>

--- a/bootstrap4/language/es-ES/es-ES.tpl_bootstrap4.ini
+++ b/bootstrap4/language/es-ES/es-ES.tpl_bootstrap4.ini
@@ -1,0 +1,10 @@
+; Joomla! Project
+; Copyright (C) 2005 - 2015 Open Source Matters. All rights reserved.
+; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
+; Note : All ini files need to be saved as UTF-8
+
+TPL_BOOTSTRAP4_XML_DESCRIPTION="Plantilla frontal con soporte para Bootstrap 4."
+TPL_BOOTSTRAP4_FAVICON="Favicon"
+TPL_BOOTSTRAP4_FAVICON_DESC="Icono mostrado en la barra de direcciones del navegador web."
+
+TPL_BOOTSTRAP4_BACKTOTOP="Volver arriba"

--- a/bootstrap4/language/es-ES/es-ES.tpl_bootstrap4.sys.ini
+++ b/bootstrap4/language/es-ES/es-ES.tpl_bootstrap4.sys.ini
@@ -1,0 +1,27 @@
+; Joomla! Project
+; Copyright (C) 2005 - 2015 Open Source Matters. All rights reserved.
+; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
+; Note : All ini files need to be saved as UTF-8
+
+TPL_BOOTSTRAP4_XML_DESCRIPTION="Plantilla frontal con soporte para Bootstrap 4."
+TPL_BOOTSTRAP4_FAVICON="Favicon"
+TPL_BOOTSTRAP4_FAVICON_DESC="Icono mostrado en la barra de direcciones del navegador web."
+
+TPL_BOOTSTRAP4_POSITION_BANNER="Banner"
+TPL_BOOTSTRAP4_POSITION_DEBUG="Depuración"
+TPL_BOOTSTRAP4_POSITION_BREADCRUMBS="Migas de pan"
+TPL_BOOTSTRAP4_POSITION_SIDEBAR-LEFT="Barra lateral izquierda"
+TPL_BOOTSTRAP4_POSITION_SIDEBAR-RIGHT="Barra lateral derecha"
+TPL_BOOTSTRAP4_POSITION_NAVBAR-1="Izquierda de la barra de navegación"
+TPL_BOOTSTRAP4_POSITION_NAVBAR-2="Derecha de la barra de navegación"
+TPL_BOOTSTRAP4_POSITION_CONTRIBUTORS="Colaboradores"
+TPL_BOOTSTRAP4_POSITION_POSITION-6="No se usa"
+TPL_BOOTSTRAP4_POSITION_POSITION-7="No se usa"
+TPL_BOOTSTRAP4_POSITION_POSITION-8="No se usa"
+TPL_BOOTSTRAP4_POSITION_POSITION-9="No se usa"
+TPL_BOOTSTRAP4_POSITION_POSITION-10="No se usa"
+TPL_BOOTSTRAP4_POSITION_POSITION-11="No se usa"
+TPL_BOOTSTRAP4_POSITION_POSITION-12="No se usa"
+TPL_BOOTSTRAP4_POSITION_POSITION-13="No se usa"
+TPL_BOOTSTRAP4_POSITION_POSITION-14="No se usa"
+TPL_BOOTSTRAP4_POSITION_FOOTER="Footer"


### PR DESCRIPTION
According to #10 there's an error on loada orders. This commit aims to solve CSS order issue and places the Javascript files at the bottom of <body> tag.

Further improvement on JS loading could be achieved by using defer and async option from the addScript function. This should be a theme option for admins within the backend.